### PR TITLE
added a delete subscription so that the api is consistent

### DIFF
--- a/XamarinStripe/StripePayment.cs
+++ b/XamarinStripe/StripePayment.cs
@@ -384,6 +384,13 @@ namespace Xamarin.Payments.Stripe {
             string ep = string.Format (subscription_path + "?at_period_end={2}", api_endpoint, HttpUtility.UrlEncode (customerId), atPeriodEnd.ToString (CultureInfo.InvariantCulture).ToLowerInvariant ());
             return DoRequest<StripeSubscription> (ep, "DELETE", null);
         }
+
+        public StripeSubscription DeleteSubscription(string customerId, bool atPeriodEnd)
+        {
+            return Unsubscribe(customerId, atPeriodEnd);
+        }
+
+
         #endregion
         #region Invoice items
         public StripeInvoiceItem CreateInvoiceItem (StripeInvoiceItemInfo item)


### PR DESCRIPTION
I realize this is a rather simple alias, but It took me a few minutes to find the unsubscribe when most other things that use the Delete verb are starting with Delete in this api.
