### PR TITLE
Updated StripeCoupon to support both percent/amount off

### DIFF
--- a/XamarinStripe/StripeCoupon.cs
+++ b/XamarinStripe/StripeCoupon.cs
@@ -32,7 +32,10 @@ namespace Xamarin.Payments.Stripe {
         public StripeCouponDuration Duration { get; set; }
 
         [JsonProperty (PropertyName = "percent_off")]
-        public int PercentOff { get; set; }
+        public int? PercentOff { get; set; }
+
+        [JsonProperty(PropertyName = "amount_off")]
+        public int? AmountOff { get; set; }
 
         [JsonProperty (PropertyName = "deleted")]
         public bool? Deleted { get; set; }


### PR DESCRIPTION
Stripe allows for a coupon to be defined in terms of either percent
off or amount off. Previous StripeCoupon.cs code assumed that the
coupon could only be PercentOff and crashed when JSON percent_off was
null.

This patch changes percent_off to nullable-int and introduces a new
member amount_off, also nullable-int.

Stripe coupons are required to have one and only one of these two
properties set. As such, any usage of these variables should be
tested for HasValue before use.

Note that this is a breaking API change, code using old API will need
to be updated to work with this change, and swapping out the DLLs
without recompiling will cause code to crash if an attempt to use
StripeCoupon is made.
