### PR TITLE
Added ammount info 

### DIFF
--- a/XamarinStripe/StripeCouponInfo.cs
+++ b/XamarinStripe/StripeCouponInfo.cs
@@ -20,11 +20,15 @@ using System;
 using System.Text;
 using System.Web;
 
-namespace Xamarin.Payments.Stripe {
-    public class StripeCouponInfo : IUrlEncoderInfo {
+namespace Xamarin.Payments.Stripe
+{
+    public class StripeCouponInfo : IUrlEncoderInfo
+    {
         public string ID { get; set; }
 
         public int PercentOff { get; set; }
+
+        public int AmmountOff { get; set; }
 
         public StripeCouponDuration Duration { get; set; }
 
@@ -35,17 +39,25 @@ namespace Xamarin.Payments.Stripe {
         public DateTime RedeemBy { get; set; }
 
         #region IUrlEncoderInfo implementation
-        public virtual void UrlEncode (StringBuilder sb)
+        public virtual void UrlEncode(StringBuilder sb)
         {
-            sb.AppendFormat ("percent_off={0}&duration={1}&", PercentOff, HttpUtility.UrlEncode (Duration.ToString ().ToLower ()));
-            if (!string.IsNullOrEmpty (ID))
-                sb.AppendFormat ("id={0}&", HttpUtility.UrlEncode (ID));
+            if (AmmountOff > 0)
+            {
+                sb.AppendFormat("amount_off={0}", AmmountOff);
+            }
+            else
+            {
+                sb.AppendFormat("percent_off={0}", PercentOff);
+            }
+            sb.AppendFormat("&duration={0}&", HttpUtility.UrlEncode(Duration.ToString().ToLower()));
+            if (!string.IsNullOrEmpty(ID))
+                sb.AppendFormat("id={0}&", HttpUtility.UrlEncode(ID));
             if (MonthsForDuration > 0)
-                sb.AppendFormat ("duration_in_months={0}&", MonthsForDuration);
+                sb.AppendFormat("duration_in_months={0}&", MonthsForDuration);
             if (MaxRedemptions > 0)
-                sb.AppendFormat ("max_redemptions={0}&", MaxRedemptions);
+                sb.AppendFormat("max_redemptions={0}&", MaxRedemptions);
             if (RedeemBy != DateTime.MinValue)
-                sb.AppendFormat ("redeem_by={0}&", RedeemBy.ToUnixEpoch ());
+                sb.AppendFormat("redeem_by={0}&", RedeemBy.ToUnixEpoch());
         }
         #endregion
     }


### PR DESCRIPTION
Cannot add ammount off data to stripe coupon: https://stripe.com/docs/api#coupons

{
  "id": "3aad47aaa913405884785e8ae475c886",
  "percent_off": 10,
  "amount_off": null,
  "currency": "usd",
  "object": "coupon",
  "livemode": false,
  "duration": "once",
  "redeem_by": null,
  "max_redemptions": null,
  "times_redeemed": 0,
  "duration_in_months": null
}
