### PR TITLE
Add missing Invoice ID to Invoice Item

### DIFF
--- a/XamarinStripe/StripeInvoice.cs
+++ b/XamarinStripe/StripeInvoice.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Payments.Stripe {
         public bool Attempted { get; set; }
 
         [JsonProperty ("attempt_count")]
-        int AttemptCount { get; set; }
+        public int AttemptCount { get; set; }
 
         [JsonProperty ("closed")]
         public bool Closed { get; set; }

--- a/XamarinStripe/StripeInvoiceItem.cs
+++ b/XamarinStripe/StripeInvoiceItem.cs
@@ -40,5 +40,8 @@ namespace Xamarin.Payments.Stripe {
 
         [JsonProperty (PropertyName = "deleted")]
         public bool? Deleted { get; set; }
+        
+        [JsonProperty (PropertyName = "invoice")]
+        public string InvoiceID { get; set; }
     }
 }

--- a/XamarinStripe/StripeInvoiceItemInfo.cs
+++ b/XamarinStripe/StripeInvoiceItemInfo.cs
@@ -23,6 +23,8 @@ using System.Web;
 namespace Xamarin.Payments.Stripe {
     public class StripeInvoiceItemInfo : IUrlEncoderInfo {
         public string CustomerID { get; set; }
+        
+        public string InvoiceID { get; set; }
 
         public int Amount { get; set; }
 
@@ -37,6 +39,8 @@ namespace Xamarin.Payments.Stripe {
                 HttpUtility.UrlEncode (CustomerID), Amount, HttpUtility.UrlEncode (Currency ?? "usd"));
             if (!string.IsNullOrEmpty (Description))
                 sb.AppendFormat ("description={0}&", HttpUtility.UrlEncode (Description));
+            if (!string.IsNullOrEmpty (InvoiceID))
+                sb.AppendFormat ("invoice={0}&", HttpUtility.UrlEncode (InvoiceID));
         }
         #endregion
     }


### PR DESCRIPTION
Stripe allows adding Invoice Items to an existing invoice by passing the invoice id when creating an invoice item. Plus a minor property fix.
