### PR TITLE
Move query string ampersand to beginning of conditional params

### DIFF
--- a/XamarinStripe/StripeInvoiceItemInfo.cs
+++ b/XamarinStripe/StripeInvoiceItemInfo.cs
@@ -38,9 +38,9 @@ namespace Xamarin.Payments.Stripe {
             sb.AppendFormat ("customer={0}&amount={1}&currency={2}&",
                 HttpUtility.UrlEncode (CustomerID), Amount, HttpUtility.UrlEncode (Currency ?? "usd"));
             if (!string.IsNullOrEmpty (Description))
-                sb.AppendFormat ("description={0}&", HttpUtility.UrlEncode (Description));
+                sb.AppendFormat ("&description={0}", HttpUtility.UrlEncode (Description));
             if (!string.IsNullOrEmpty (InvoiceID))
-                sb.AppendFormat ("invoice={0}&", HttpUtility.UrlEncode (InvoiceID));
+                sb.AppendFormat ("&invoice={0}", HttpUtility.UrlEncode (InvoiceID));
         }
         #endregion
     }

--- a/XamarinStripe/StripeInvoiceItemInfo.cs
+++ b/XamarinStripe/StripeInvoiceItemInfo.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Payments.Stripe {
         #region IUrlEncoderInfo implementation
         public virtual void UrlEncode (StringBuilder sb)
         {
-            sb.AppendFormat ("customer={0}&amount={1}&currency={2}&",
+            sb.AppendFormat ("customer={0}&amount={1}&currency={2}",
                 HttpUtility.UrlEncode (CustomerID), Amount, HttpUtility.UrlEncode (Currency ?? "usd"));
             if (!string.IsNullOrEmpty (Description))
                 sb.AppendFormat ("&description={0}", HttpUtility.UrlEncode (Description));


### PR DESCRIPTION
Silly bug, didn't catch it until production
