### PR TITLE
Support for Balance Transactions

### DIFF
--- a/XamarinStripe/StripeBalanceTransaction.cs
+++ b/XamarinStripe/StripeBalanceTransaction.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Payments.Stripe {
         [JsonProperty ("currency")]
         public string Currency { get; set; }
 
-        [JsonProperty ("available_on")]
+        [JsonProperty ("net")]
         public int Net { get; set; }
 
         [JsonProperty ("fee")]

--- a/XamarinStripe/StripeCharge.cs
+++ b/XamarinStripe/StripeCharge.cs
@@ -33,8 +33,13 @@ namespace Xamarin.Payments.Stripe {
         public bool Paid { get; set; }
         [JsonProperty (PropertyName = "amount")]
         public int Amount { get; set; }
+        /* api changed */
+        /*
         [JsonProperty (PropertyName = "fee")]
         public int Fee { get; set; }
+         */
+        [JsonProperty (PropertyName = "balance_transaction")]
+        public string BalanceTransaction { get; set; }
         [JsonProperty (PropertyName = "livemode")]
         public bool LiveMode { get; set; }
         /* api changed */

--- a/XamarinStripe/StripePayment.cs
+++ b/XamarinStripe/StripePayment.cs
@@ -495,6 +495,15 @@ namespace Xamarin.Payments.Stripe {
             return DoRequest<StripeCollection<StripeLineItem>> (ep);
         }
         #endregion
+        #region Balance transactions
+        public StripeBalanceTransaction GetBalanceTransaction (string transactionId)
+        {
+            if (string.IsNullOrEmpty (transactionId))
+                throw new ArgumentNullException ("transactionId");
+            string ep = string.Format ("{0}/balance/history/{1}", api_endpoint, HttpUtility.UrlEncode (transactionId));
+            return DoRequest<StripeBalanceTransaction> (ep);
+        }
+        #endregion
         #region Coupons
         public StripeCoupon CreateCoupon (StripeCouponInfo coupon)
         {


### PR DESCRIPTION
I switched to a recent API version in Stripe and the fee is no longer a simple part of the Charge object.  You have to get the balance transaction for the charge and look up the balance transaction object.  (https://stripe.com/docs/upgrades#2013-08-13)

I can't find a .net API library that supports this.  So I modified yours.

I disabled charge.fee, but perhaps it should be left in to support both the old API and the new API.
