### PR TITLE
Update projects to point to .NET 4.5 and use TLS 1.2

### DIFF
--- a/PaymentTest/PaymentTest.csproj
+++ b/PaymentTest/PaymentTest.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -11,6 +11,8 @@
     <RootNamespace>PaymentTest</RootNamespace>
     <AssemblyName>PaymentTest</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -21,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -30,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/PaymentTest/Program.cs
+++ b/PaymentTest/Program.cs
@@ -47,7 +47,7 @@ namespace PaymentTest {
             StripeCreditCardInfo cc = new StripeCreditCardInfo ();
             cc.CVC = "1234";
             cc.ExpirationMonth = 6;
-            cc.ExpirationYear = 2015;
+            cc.ExpirationYear = 2017;
             cc.Number = "4242424242424242";
             return cc;
         }

--- a/PaymentTest/app.config
+++ b/PaymentTest/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/XamarinStripe/StripePayment.cs
+++ b/XamarinStripe/StripePayment.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Payments.Stripe {
         #region Shared
         protected virtual WebRequest SetupRequest (string method, string url)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             WebRequest req = (WebRequest) WebRequest.Create (url);
             req.Method = method;
             if (req is HttpWebRequest) {

--- a/XamarinStripe/XamarinStripe.csproj
+++ b/XamarinStripe/XamarinStripe.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,6 +11,8 @@
     <RootNamespace>Xamarin.Payments.Stripe</RootNamespace>
     <AssemblyName>XamarinStripe</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/XamarinStripe/packages.config
+++ b/XamarinStripe/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
With Stripe's new update to require TLS 1.2, this will allow this project to continue to work with the updated API. It also requires upgrading the project to .NET 4.5 because WebRequest does not support TLS 1.2 until .NET 4.5.
